### PR TITLE
feat: htmlContent支持jsx

### DIFF
--- a/packages/shadow-render-react/src/ShadowRender/utils.ts
+++ b/packages/shadow-render-react/src/ShadowRender/utils.ts
@@ -61,7 +61,6 @@ export async function render(children: ReactNode, container: HTMLElement) {
 /**
  * 卸载container中的React状态
  * @param container dom节点
- * @param isUnMount 是否是卸载组件
  */
 export function unMoutReactByNode(container: HTMLElement) {
   const reactRoot = reactRootMap.get(container);

--- a/packages/shadow-render-react/src/ShadowRender/utils.ts
+++ b/packages/shadow-render-react/src/ShadowRender/utils.ts
@@ -1,3 +1,7 @@
+import type { ReactNode } from 'react';
+import { unmountComponentAtNode } from 'react-dom';
+import type { Root } from 'react-dom/client';
+
 /**
  * 从节点中通过选择器找到元素并移除
  * @param node 要移除元素的父节点
@@ -18,4 +22,53 @@ export function setAttributes(node: HTMLElement, attrs: Record<string, string>) 
   Object.keys(attrs).forEach((key) => {
     node.setAttribute(key, attrs[key]);
   });
+}
+
+/**
+ * 根据container缓存ReactRoot
+ * 同一个container只能存在一个createRoot实例
+ * 如果同一个container存在多个实例，React会抛出警告
+ * 重复render时，无需新建Root
+ */
+const reactRootMap = new Map<HTMLElement, Root>();
+
+/**
+ * 兼容React各版render API
+ */
+export async function render(children: ReactNode, container: HTMLElement) {
+  let createRoot;
+  try {
+    // @ts-ignore
+    const { createRoot: reactCreateRoot } = await import('react-dom/client');
+    createRoot = reactCreateRoot;
+  } finally {
+    if (createRoot) {
+      let reactRoot = reactRootMap.get(container);
+      if (!reactRoot) {
+        reactRoot = createRoot(container);
+        reactRootMap.set(container, reactRoot);
+      }
+      reactRootMap.set(container, reactRoot);
+      reactRoot.render(children);
+    } else {
+      const { render } = await import('react-dom');
+      // @ts-ignore
+      render(children, container);
+    }
+  }
+}
+
+/**
+ * 卸载container中的React状态
+ * @param container dom节点
+ * @param isUnMount 是否是卸载组件
+ */
+export function unMoutReactByNode(container: HTMLElement) {
+  const reactRoot = reactRootMap.get(container);
+  if (reactRoot) {
+    reactRoot.unmount();
+    reactRootMap.delete(container);
+  } else {
+    unmountComponentAtNode(container);
+  }
 }

--- a/packages/shadow-render-react/tests/ShadowRender.test.tsx
+++ b/packages/shadow-render-react/tests/ShadowRender.test.tsx
@@ -38,24 +38,40 @@ describe('ShadowRender test', () => {
     render(<ShadowRender htmlContent="<h1>Hello</h1>" ref={ref} />);
 
     await waitFor(() => screen.findByShadowText('Hello'));
-    expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<div><h1>Hello</h1></div>');
   });
 
   test('htmlContent value maybe an ReactElement', async () => {
     const ref: RefObject<ShadowRenderRef> = createRef();
-    render(<ShadowRender htmlContent={<h1>Hello</h1>} ref={ref} />);
+    render(
+      <ShadowRender ref={ref}>
+        <h1>Hello</h1>
+      </ShadowRender>
+    );
 
     await waitFor(() => screen.findByShadowText('Hello'));
-    expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<div><h1>Hello</h1></div>');
+  });
+
+  test('when htmlContent and children exist at the same time will render htmlContent', async () => {
+    const ref: RefObject<ShadowRenderRef> = createRef();
+    render(<ShadowRender htmlContent="<h1>htmlContent</h1>" ref={ref} children={<h1>children</h1>} />);
+
+    await waitFor(() => screen.findByShadowText('htmlContent'));
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<div><h1>htmlContent</h1></div>');
   });
 
   test('htmlContent value maybe an Component', async () => {
     const ref: RefObject<ShadowRenderRef> = createRef();
     const Component = () => <h1>Hello</h1>;
-    render(<ShadowRender htmlContent={<Component />} ref={ref} />);
+    render(
+      <ShadowRender ref={ref}>
+        <Component />
+      </ShadowRender>
+    );
 
     await waitFor(() => screen.findByShadowText('Hello'));
-    expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<div><h1>Hello</h1></div>');
   });
 
   test('set dynamic styles ok', async () => {

--- a/packages/shadow-render-react/tests/ShadowRender.test.tsx
+++ b/packages/shadow-render-react/tests/ShadowRender.test.tsx
@@ -41,6 +41,23 @@ describe('ShadowRender test', () => {
     expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
   });
 
+  test('htmlContent value maybe an ReactElement', async () => {
+    const ref: RefObject<ShadowRenderRef> = createRef();
+    render(<ShadowRender htmlContent={<h1>Hello</h1>} ref={ref} />);
+
+    await waitFor(() => screen.findByShadowText('Hello'));
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
+  });
+
+  test('htmlContent value maybe an Component', async () => {
+    const ref: RefObject<ShadowRenderRef> = createRef();
+    const Component = () => <h1>Hello</h1>;
+    render(<ShadowRender htmlContent={<Component />} ref={ref} />);
+
+    await waitFor(() => screen.findByShadowText('Hello'));
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
+  });
+
   test('set dynamic styles ok', async () => {
     render(
       <ShadowRender

--- a/packages/shadow-render-react/tests/ShadowRender.test.tsx
+++ b/packages/shadow-render-react/tests/ShadowRender.test.tsx
@@ -38,7 +38,7 @@ describe('ShadowRender test', () => {
     render(<ShadowRender htmlContent="<h1>Hello</h1>" ref={ref} />);
 
     await waitFor(() => screen.findByShadowText('Hello'));
-    expect(ref.current!.getContentDOM().innerHTML).toBe('<div><h1>Hello</h1></div>');
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
   });
 
   test('htmlContent value maybe an ReactElement', async () => {
@@ -50,7 +50,7 @@ describe('ShadowRender test', () => {
     );
 
     await waitFor(() => screen.findByShadowText('Hello'));
-    expect(ref.current!.getContentDOM().innerHTML).toBe('<div><h1>Hello</h1></div>');
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
   });
 
   test('when htmlContent and children exist at the same time will render htmlContent', async () => {
@@ -58,7 +58,7 @@ describe('ShadowRender test', () => {
     render(<ShadowRender htmlContent="<h1>htmlContent</h1>" ref={ref} children={<h1>children</h1>} />);
 
     await waitFor(() => screen.findByShadowText('htmlContent'));
-    expect(ref.current!.getContentDOM().innerHTML).toBe('<div><h1>htmlContent</h1></div>');
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>htmlContent</h1>');
   });
 
   test('htmlContent value maybe an Component', async () => {
@@ -71,7 +71,7 @@ describe('ShadowRender test', () => {
     );
 
     await waitFor(() => screen.findByShadowText('Hello'));
-    expect(ref.current!.getContentDOM().innerHTML).toBe('<div><h1>Hello</h1></div>');
+    expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
   });
 
   test('set dynamic styles ok', async () => {

--- a/packages/shadow-render-react/tests/ShadowRender.test.tsx
+++ b/packages/shadow-render-react/tests/ShadowRender.test.tsx
@@ -1,5 +1,5 @@
 import { ShadowRender, ShadowRenderRef } from '../src';
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 // 测试 shadow dom 需要
 import { screen } from 'shadow-dom-testing-library';
 import React, { createRef, RefObject } from 'react';
@@ -72,6 +72,39 @@ describe('ShadowRender test', () => {
 
     await waitFor(() => screen.findByShadowText('Hello'));
     expect(ref.current!.getContentDOM().innerHTML).toBe('<h1>Hello</h1>');
+  });
+
+  test('when-htmlContent-and-children-values-change-be-ok', async () => {
+    const ref: RefObject<ShadowRenderRef> = createRef();
+    const Component = () => {
+      const [count, setCount] = React.useState(0);
+      const [htmlContent, setContent] = React.useState<string | undefined>(undefined);
+      return (
+        <>
+          <button id="increment" onClick={() => setCount(count + 1)}>
+            add
+          </button>
+          <button id="hiddenContent" onClick={() => setContent(undefined)}>
+            hidden
+          </button>
+          <button id="showContent" onClick={() => setContent('hello')}>
+            show
+          </button>
+          <ShadowRender ref={ref} htmlContent={htmlContent} children={<div>{count}</div>}></ShadowRender>
+        </>
+      );
+    };
+    render(<Component />);
+
+    await waitFor(() => screen.findByShadowText('0'));
+    fireEvent.click(screen.getByText('add'));
+    await waitFor(() => screen.findByShadowText('1'));
+    fireEvent.click(screen.getByText('show'));
+    await waitFor(() => screen.findByShadowText('hello'));
+    fireEvent.click(screen.getByText('add'));
+    await waitFor(() => screen.findByShadowText('hello'));
+    fireEvent.click(screen.getByText('hidden'));
+    await waitFor(() => screen.findByShadowText('2'));
   });
 
   test('set dynamic styles ok', async () => {


### PR DESCRIPTION
htmlContent目前只支持文本html,当前我对它做了一些拓展,让它可以支持jsx。
for example:
```tsx
<ShadowRender ref={shadowRenderRef}>
    <h1>Hello</h1>
</ShadowRender >
```